### PR TITLE
Fix - incorrect package usage for .NET Core 3.1

### DIFF
--- a/src/Arcus.EventGrid.Proxy.Api/Arcus.EventGrid.Proxy.Api.csproj
+++ b/src/Arcus.EventGrid.Proxy.Api/Arcus.EventGrid.Proxy.Api.csproj
@@ -24,10 +24,9 @@
     <PackageReference Include="Arcus.EventGrid.Publishing" Version="3.1.0" />
     <PackageReference Include="Arcus.WebApi.Correlation" Version="0.4.0" />
     <PackageReference Include="Arcus.WebApi.Logging" Version="1.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.11" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.5" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.6.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.6.3" />
   </ItemGroup>

--- a/src/Arcus.EventGrid.Proxy.Tests.Integration/Arcus.EventGrid.Proxy.Tests.Integration.csproj
+++ b/src/Arcus.EventGrid.Proxy.Tests.Integration/Arcus.EventGrid.Proxy.Tests.Integration.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="Arcus.EventGrid.Testing" Version="3.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Arcus.EventGrid.Proxy.Tests.Unit/Arcus.EventGrid.Proxy.Tests.Unit.csproj
+++ b/src/Arcus.EventGrid.Proxy.Tests.Unit/Arcus.EventGrid.Proxy.Tests.Unit.csproj
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
The web code generation package was using a version not compatible with .NET Core 3.1.